### PR TITLE
readme: add note about supply chain attacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ jobs:
           service_account_key: ${{ secrets.GCP_SA_INFRA_KEY }}
           export_default_credentials: true
       - name: rotate gcp keys
-        uses: miklosn/github-action-rotate-gcp-key@main
+        uses: miklosn/github-action-rotate-gcp-key@main # WARNING: use explicit Git commit sha instead of 'main' to avoid becoming a victim of supply chain attacks
         with:
           projectId: "example"
           serviceAccount: "github-actions@example.iam.gserviceaccount.com"


### PR DESCRIPTION
Hi, I think it would be good to add this note to the example.

Basically in the (unlikely) event that your GitHub account would be hacked and someone publishes a new version of the GitHub Action, all users GCP keys could be compromised if they use `@main`.

Even `@v1.2` might not be save as git tags can be deleted and re-created with a different SHA associated

For most actions this is less of an issue, but considering we're dealing with very sensitive credentials here I think it's worth mentioning explicitly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/miklosn/github-action-rotate-gcp-key/1)
<!-- Reviewable:end -->
